### PR TITLE
#11 Achieve order of magnitude speedup of parser

### DIFF
--- a/edtf/parser/tests.py
+++ b/edtf/parser/tests.py
@@ -189,16 +189,15 @@ BAD_EXAMPLES = (
     'y17e7-12-26', # not implemented
     '2016-13-08', # wrong day order
     '2016-02-39', # out of range
+    '-0000-01-01',  # negative zero year
 )
 
 class TestParsing(unittest.TestCase):
-
 
     def test_non_parsing(self):
         for i in BAD_EXAMPLES:
             self.assertRaises(EDTFParseException, parse, i)
 
-    @unittest.skip("takes a long time")
     def test_date_values(self):
         """
         Test that every EDTFObject can tell you its lower and upper

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,12 @@ setuptools.setup(
         'python-dateutil',
         'pyparsing',
     ],
+    extras_require={
+        'test': [
+            'django',
+            'nose',
+        ],
+    },
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
- use faster pyparsing grammar constructs and
  arrangements to significantly speed up parsing
- enable skipped parsing unit tests now that they
  are not infeasibly slow
- add testing requirements to setup.py

Anecdotal speed increase is from about 30 seconds
to run the `test_date_values` tests down to below
3 seconds.

See also #17