### PR TITLE
Python 3 Compatibility

### DIFF
--- a/edtf/__init__.py
+++ b/edtf/__init__.py
@@ -1,3 +1,3 @@
-from parser.grammar import parse_edtf
-from natlang import text_to_edtf
-from parser.parser_classes import *
+from edtf.parser.grammar import parse_edtf
+from edtf.natlang import text_to_edtf
+from edtf.parser.parser_classes import *

--- a/edtf/fields.py
+++ b/edtf/fields.py
@@ -6,7 +6,7 @@ except:
 from django.db import models
 
 from edtf import parse_edtf, EDTFObject
-from natlang import text_to_edtf
+from edtf.natlang import text_to_edtf
 
 DATE_ATTRS = (
     'lower_strict',

--- a/edtf/fields.py
+++ b/edtf/fields.py
@@ -15,6 +15,7 @@ DATE_ATTRS = (
     'upper_fuzzy',
 )
 
+
 class EDTFField(models.CharField):
 
     def __init__(
@@ -35,7 +36,6 @@ class EDTFField(models.CharField):
         super(EDTFField, self).__init__(verbose_name, name, **kwargs)
 
     description = "An field for storing complex/fuzzy date specifications in EDTF format."
-
 
     def deconstruct(self):
         name, path, args, kwargs = super(EDTFField, self).deconstruct()

--- a/edtf/natlang/__init__.py
+++ b/edtf/natlang/__init__.py
@@ -1,1 +1,1 @@
-from en import text_to_edtf
+from .en import text_to_edtf

--- a/edtf/natlang/en.py
+++ b/edtf/natlang/en.py
@@ -3,12 +3,13 @@ from datetime import datetime
 from dateutil.parser import parse
 import re
 from edtf import appsettings
+from six.moves import xrange
 
 
 # two dates where every digit of an ISO date representation is different,
 # and one is in the past and one is in the future.
 # This is used in the dateutil parse to detect which elements weren't parsed.
-DEFAULT_DATE_1 = datetime(1234, 01, 01, 0, 0)
+DEFAULT_DATE_1 = datetime(1234, 1, 1, 0, 0)
 DEFAULT_DATE_2 = datetime(5678, 10, 10, 0, 0)
 
 SHORT_YEAR_RE = r'(-?)([\du])([\dxu])([\dxu])([\dxu])'

--- a/edtf/natlang/en.py
+++ b/edtf/natlang/en.py
@@ -16,6 +16,7 @@ LONG_YEAR_RE = r'y(-?)([1-9]\d\d\d\d+)'
 CENTURY_RE = r'(\d{1,2})(c\.?|(st|nd|rd|th) century)\s?(ad|ce|bc|bce)?'
 CE_RE = r'(\d{1,4}) (ad|ce|bc|bce)'
 
+
 def text_to_edtf(text):
     """
     Generate EDTF string equivalent of a given natural language date string.
@@ -55,7 +56,6 @@ def text_to_edtf(text):
                             g = century_range_match.groups()
                             d1 = "%sC" % g[0]
                             d2 = "%sC" % g[2]
-
 
                     # import pdb; pdb.set_trace()
                     r1 = text_to_edtf_date(d1)

--- a/edtf/natlang/tests.py
+++ b/edtf/natlang/tests.py
@@ -202,7 +202,7 @@ class TestLevel0(unittest.TestCase):
         """
         for i, o in EXAMPLES:
             e = text_to_edtf(i)
-            print "%s => %s" % (i, e)
+            print("%s => %s" % (i, e))
             self.assertEqual(e, o)
 
 

--- a/edtf/natlang/tests.py
+++ b/edtf/natlang/tests.py
@@ -191,8 +191,8 @@ EXAMPLES = (
     # ('about July? in about 1849', '1849~-07?~'),
 )
 
-class TestLevel0(unittest.TestCase):
 
+class TestLevel0(unittest.TestCase):
     def test_natlang(self):
         """
         For each of the examples, establish that:
@@ -204,7 +204,6 @@ class TestLevel0(unittest.TestCase):
             e = text_to_edtf(i)
             print "%s => %s" % (i, e)
             self.assertEqual(e, o)
-
 
 
 if __name__ == '__main__':

--- a/edtf/natlang/tests.py
+++ b/edtf/natlang/tests.py
@@ -1,5 +1,5 @@
 import unittest
-from en import text_to_edtf
+from edtf.natlang.en import text_to_edtf
 
 # where examples are tuples, the second item is the normalised output
 EXAMPLES = (

--- a/edtf/parser/__init__.py
+++ b/edtf/parser/__init__.py
@@ -1,2 +1,2 @@
-from grammar import parse_edtf
-from parser_classes import *
+from edtf.parser.grammar import parse_edtf
+from edtf.parser.parser_classes import *

--- a/edtf/parser/grammar.py
+++ b/edtf/parser/grammar.py
@@ -2,13 +2,13 @@ from pyparsing import Literal as L, ParseException, Optional, OneOrMore, \
     ZeroOrMore, oneOf, Regex, Combine, Word, NotAny, nums
 
 # (* ************************** Level 0 *************************** *)
-from parser_classes import Date, DateAndTime, Interval, Unspecified, \
+from edtf.parser.parser_classes import Date, DateAndTime, Interval, Unspecified, \
     UncertainOrApproximate, Level1Interval, LongYear, Season, \
     PartialUncertainOrApproximate, UA, PartialUnspecified, OneOfASet, \
     Consecutives, EarlierConsecutives, LaterConsecutives, MultipleDates, \
     MaskedPrecision, Level2Interval, ExponentialYear
 
-from edtf_exceptions import EDTFParseException
+from edtf.parser.edtf_exceptions import EDTFParseException
 
 oneThru12 = oneOf(['%.2d' % i for i in range(1, 13)])
 oneThru13 = oneOf(['%.2d' % i for i in range(1, 14)])

--- a/edtf/parser/grammar.py
+++ b/edtf/parser/grammar.py
@@ -95,6 +95,8 @@ LongYear.set_parser(longYearSimple)
 # (* *** L1Interval *** *)
 uaDateOrSeason = dateOrSeason + Optional(UASymbol)
 l1Start = uaDateOrSeason ^ "unknown"
+
+
 # bit of a kludge here to get the all the relevant tokens into the parse action
 # cleanly otherwise the parameter names are overlapped.
 def f(toks):
@@ -102,6 +104,8 @@ def f(toks):
         return {'date': toks[0], 'ua': toks[1]}
     except IndexError:
         return {'date': toks[0], 'ua': None}
+
+
 l1Start.addParseAction(f)
 l1End = uaDateOrSeason ^ "unknown" ^ "open"
 l1End.addParseAction(f)
@@ -272,6 +276,7 @@ level2Expression = partialUncertainOrApproximate \
 
 # putting it all together
 edtfParser = level0Expression("level0") ^ level1Expression("level1") ^ level2Expression("level2")
+
 
 def parse_edtf(str, parseAll=True, fail_silently=False):
     try:

--- a/edtf/parser/parser_classes.py
+++ b/edtf/parser/parser_classes.py
@@ -43,7 +43,7 @@ class EDTFObject(object):
         return cls.parser.parseString(s)[0]
 
     def __repr__(self):
-        return "%s: '%s'" % (type(self).__name__, unicode(self))
+        return "%s: '%s'" % (type(self).__name__, str(self))
 
     def __init__(self, *args, **kwargs):
         str = "%s.__init__(*%s, **%s)" % (
@@ -52,7 +52,7 @@ class EDTFObject(object):
         )
         raise NotImplementedError("%s is not implemented." % str)
 
-    def __unicode__(self):
+    def __str__(self):
         raise NotImplementedError
 
     def _strict_date(self, lean):
@@ -100,16 +100,16 @@ class EDTFObject(object):
 
     def __eq__(self, other):
         if isinstance(other, EDTFObject):
-            return unicode(self) == unicode(other)
+            return str(self) == str(other)
         elif isinstance(other, date):
-            return unicode(self) == other.isoformat()
+            return str(self) == other.isoformat()
         return False
 
     def __ne__(self, other):
         if isinstance(other, EDTFObject):
-            return unicode(self) != unicode(other)
+            return str(self) != str(other)
         elif isinstance(other, date):
-            return unicode(self) != other.isoformat()
+            return str(self) != other.isoformat()
         return True
 
     def __gt__(self, other):
@@ -173,23 +173,23 @@ class Date(EDTFObject):
         self.month = month
         self.day = day
 
-    def __unicode__(self):
+    def __str__(self):
         r = self.year
         if self.month:
-            r += u"-%s" % self.month
+            r += "-%s" % self.month
             if self.day:
-                r += u"-%s" % self.day
+                r += "-%s" % self.day
         return r
 
     def isoformat(self, default=date.max):
-        return u"%s-%02d-%02d" % (
+        return "%s-%02d-%02d" % (
             self.year,
             int(self.month or default.month),
             int(self.day or default.day),
         )
 
     def _precise_year(self, lean):
-        "Replace any ambiguous characters in the year string with 0s or 9s"
+        # Replace any ambiguous characters in the year string with 0s or 9s
         if lean == EARLIEST:
             return int(re.sub(r'[xu]', r'0', self.year))
         else:
@@ -230,7 +230,7 @@ class Date(EDTFObject):
             'day': self._precise_day(lean),
         }
 
-        isoish = u"%(year)s-%(month)02d-%(day)02d" % parts
+        isoish = "%(year)s-%(month)02d-%(day)02d" % parts
 
         try:
             dt = parse(
@@ -262,7 +262,7 @@ class DateAndTime(EDTFObject):
         self.date = date
         self.time = time
 
-    def __unicode__(self):
+    def __str__(self):
         return self.isoformat()
 
     def isoformat(self):
@@ -287,8 +287,8 @@ class Interval(EDTFObject):
         self.lower = lower
         self.upper = upper
 
-    def __unicode__(self):
-        return u"%s/%s" % (self.lower, self.upper)
+    def __str__(self):
+        return "%s/%s" % (self.lower, self.upper)
 
     def _strict_date(self, lean):
         if lean == EARLIEST:
@@ -330,7 +330,7 @@ class UA(EDTFObject):
         self.is_uncertain = "?" in ua
         self.is_approximate = "~" in ua
 
-    def __unicode__(self):
+    def __str__(self):
         d = ""
         if self.is_uncertain:
             d += "?"
@@ -352,11 +352,11 @@ class UncertainOrApproximate(EDTFObject):
         self.date = date
         self.ua = ua
 
-    def __unicode__(self):
+    def __str__(self):
         if self.ua:
-            return u"%s%s" % (self.date, self.ua)
+            return "%s%s" % (self.date, self.ua)
         else:
-            return unicode(self.date)
+            return str(self.date)
 
     def _strict_date(self, lean):
         if self.date == "open":
@@ -398,7 +398,7 @@ class LongYear(EDTFObject):
     def __init__(self, year):
         self.year = year
 
-    def __unicode__(self):
+    def __str__(self):
         return "y%s" % self.year
 
     def _precise_year(self):
@@ -425,7 +425,7 @@ class Season(Date):
         # `Date` methods do their thing.
         self.day = None
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s-%s" % (self.year, self.season)
 
     def _precise_month(self, lean):
@@ -447,7 +447,7 @@ class PartialUncertainOrApproximate(Date):
 
     def __init__(
         self, year=None, month=None, day=None,
-        year_ua = False, month_ua = False, day_ua = False,
+        year_ua=False, month_ua = False, day_ua = False,
         year_month_ua = False, month_day_ua = False,
         ssn=None, season_ua=False, all_ua=False
     ):
@@ -467,7 +467,7 @@ class PartialUncertainOrApproximate(Date):
 
         self.all_ua = all_ua
 
-    def __unicode__(self):
+    def __str__(self):
 
         if self.season_ua:
             return "%s%s" % (self.season, self.season_ua)
@@ -475,18 +475,18 @@ class PartialUncertainOrApproximate(Date):
         if self.year_ua:
             y = "%s%s" % (self.year, self.year_ua)
         else:
-            y = unicode(self.year)
+            y = str(self.year)
 
         if self.month_ua:
             m = "(%s)%s" % (self.month, self.month_ua)
         else:
-            m = unicode(self.month)
+            m = str(self.month)
 
         if self.day:
             if self.day_ua:
                 d = "(%s)%s" % (self.day, self.day_ua)
             else:
-                d = unicode(self.day)
+                d = str(self.day)
         else:
             d = None
 
@@ -585,8 +585,8 @@ class Consecutives(Interval):
         else:
             self.upper = upper
 
-    def __unicode__(self):
-        return u"%s..%s" % (self.lower or '', self.upper or '')
+    def __str__(self):
+        return "%s..%s" % (self.lower or '', self.upper or '')
 
 
 class EarlierConsecutives(Consecutives):
@@ -606,8 +606,8 @@ class OneOfASet(EDTFObject):
     def __init__(self, *args):
         self.objects = args
 
-    def __unicode__(self):
-        return u"[%s]" % (", ".join([unicode(o) for o in self.objects]))
+    def __str__(self):
+        return "[%s]" % (", ".join([str(o) for o in self.objects]))
 
     def _strict_date(self, lean):
         if lean == LATEST:
@@ -625,8 +625,8 @@ class MultipleDates(EDTFObject):
     def __init__(self, *args):
         self.objects = args
 
-    def __unicode__(self):
-        return u"{%s}" % (", ".join([unicode(o) for o in self.objects]))
+    def __str__(self):
+        return "{%s}" % (", ".join([str(o) for o in self.objects]))
 
     def _strict_date(self, lean):
         if lean == LATEST:

--- a/edtf/parser/parser_classes.py
+++ b/edtf/parser/parser_classes.py
@@ -5,7 +5,6 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from edtf import appsettings
 
-
 EARLIEST = 'earliest'
 LATEST = 'latest'
 
@@ -73,12 +72,14 @@ class EDTFObject(object):
 
     def get_is_approximate(self):
         return getattr(self, '_is_approximate', False)
+
     def set_is_approximate(self, val):
         self._is_approximate = val
     is_approximate = property(get_is_approximate, set_is_approximate)
 
     def get_is_uncertain(self):
         return getattr(self, '_is_uncertain', False)
+
     def set_is_uncertain(self, val):
         self._is_uncertain = val
     is_uncertain = property(get_is_uncertain, set_is_uncertain)
@@ -148,6 +149,7 @@ class Date(EDTFObject):
         if y is None:
             raise AttributeError("Year must not be None")
         self._year = y
+
     def get_year(self):
         return self._year
     year = property(get_year, set_year)
@@ -156,6 +158,7 @@ class Date(EDTFObject):
         self._month = m
         if m == None:
             self.day = None
+
     def get_month(self):
         return self._month
     month = property(get_month, set_month)
@@ -217,7 +220,6 @@ class Date(EDTFObject):
             return int(self.day)
 
     def _strict_date(self, lean):
-
         py = self._precise_year(lean)
         if py < 1: # year is not positive
             return date.min
@@ -227,7 +229,6 @@ class Date(EDTFObject):
             'month': self._precise_month(lean),
             'day': self._precise_day(lean),
         }
-
 
         isoish = u"%(year)s-%(month)02d-%(day)02d" % parts
 
@@ -254,6 +255,7 @@ class Date(EDTFObject):
         if self.month:
             return PRECISION_MONTH
         return PRECISION_YEAR
+
 
 class DateAndTime(EDTFObject):
     def __init__(self, date, time):
@@ -582,7 +584,6 @@ class Consecutives(Interval):
             self.upper = Date.parse(upper)
         else:
             self.upper = upper
-
 
     def __unicode__(self):
         return u"%s..%s" % (self.lower or '', self.upper or '')

--- a/edtf/parser/parser_classes.py
+++ b/edtf/parser/parser_classes.py
@@ -35,8 +35,8 @@ class EDTFObject(object):
         try:
             return cls(**kwargs) # replace the token list with the class
         except Exception as e:
-            print "trying to %s.__init__(**%s)" % (cls.__name__, kwargs)
-            raise(e)
+            print("trying to %s.__init__(**%s)" % (cls.__name__, kwargs))
+            raise e
 
     @classmethod
     def parse(cls, s):

--- a/edtf/parser/tests.py
+++ b/edtf/parser/tests.py
@@ -199,8 +199,8 @@ BAD_EXAMPLES = (
     '-0000-01-01',  # negative zero year
 )
 
-class TestParsing(unittest.TestCase):
 
+class TestParsing(unittest.TestCase):
     def test_non_parsing(self):
         for i in BAD_EXAMPLES:
             self.assertRaises(EDTFParseException, parse, i)

--- a/edtf/parser/tests.py
+++ b/edtf/parser/tests.py
@@ -4,9 +4,9 @@ from datetime import date
 
 import sys
 
-from edtf import parse_edtf as parse
-from parser_classes import EDTFObject
-from edtf_exceptions import EDTFParseException
+from edtf.parser.grammar import parse_edtf as parse
+from edtf.parser.parser_classes import EDTFObject
+from edtf.parser.edtf_exceptions import EDTFParseException
 
 # Example object types and attributes.
 # the first item in each tuple is the input EDTF string, and expected parse result.

--- a/edtf/parser/tests.py
+++ b/edtf/parser/tests.py
@@ -222,7 +222,7 @@ class TestParsing(unittest.TestCase):
             f = parse(i)
             sys.stdout.write(" => %s()\n" % type(f).__name__)
             self.assertIsInstance(f, EDTFObject)
-            self.assertEqual(unicode(f), o)
+            self.assertEqual(str(f), o)
 
             if len(e) == 5:
                 expected_lower_strict = e[1]
@@ -254,7 +254,7 @@ class TestParsing(unittest.TestCase):
                 self.assertEqual(f.upper_fuzzy().isoformat(), expected_upper_fuzzy)
             except Exception as x:
                 # Write to stdout for manual debugging, I guess
-                sys.stdout.write(unicode(x))
+                sys.stdout.write(str(x))
                 # Re-raise exception so unit tests work for non-manual usage
                 raise
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     install_requires=[
         'python-dateutil',
         'pyparsing',
+        'six'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
This Pull Request adds Python 3 compatibility to the EDTF module. The changes are primarily focused on two areas:
 - re-working import statements to not use relative imports
 - adjusting the `repr`, `str`, and `unicode` functionality to work with Python 3.

These changes have been tested with both Python 2.7 and 3.6. All unit tests pass in both languages.
Small changes to formatting and whitespace have also been made.

This PR will fix #23 