### PR TITLE
Handle UA markers to the left of the year segment

### DIFF
--- a/edtf/parser/parser_classes.py
+++ b/edtf/parser/parser_classes.py
@@ -858,6 +858,7 @@ class PartialUncertainOrApproximate(Date):
 
         uas = [
             year_ua,
+            year_ua_b,
             month_ua,
             day_ua,
             year_month_ua,
@@ -886,7 +887,10 @@ class PartialUncertainOrApproximate(Date):
         else:
             y = f"{self.year_ua_b}{self.year}" if self.year_ua_b else str(self.year)
 
-        m = f"{self.month_ua}{self.month}" if self.month_ua else str(self.month)
+        if self.month:
+            m = f"{self.month_ua}{self.month}" if self.month_ua else str(self.month)
+        else:
+            m = None
 
         if self.day:
             d = f"{self.day_ua}{self.day}" if self.day_ua else str(self.day)
@@ -902,7 +906,12 @@ class PartialUncertainOrApproximate(Date):
             else:
                 result = f"{y}-({m}-{d}){self.month_day_ua}"
         else:
-            result = f"{y}-{m}-{d}" if d else f"{y}-{m}"
+            if d:
+                result = f"{y}-{m}-{d}"
+            elif m:
+                result = f"{y}-{m}"
+            else:
+                result = y
 
         if self.all_ua:
             result = f"({result}){self.all_ua}"

--- a/edtf/parser/tests.py
+++ b/edtf/parser/tests.py
@@ -257,6 +257,18 @@ APPROXIMATE_UNCERTAIN_EXAMPLES = (
     ("2011-~06-~04", (False, True, False)),
     ("2004-06-~01/2004-06-~20", (False, True, False)),
     ("156X~", (False, True, False)),
+    ("?1945/1959", (True, False, False)),
+    ("?1945", (True, False, False)),
+    ("?1945-01", (True, False, False)),
+    ("?1945-01-01", (True, False, False)),
+    ("~1945/1959", (False, True, False)),
+    ("~1945", (False, True, False)),
+    ("~1945-01", (False, True, False)),
+    ("~1945-01-01", (False, True, False)),
+    ("%1945/1959", (False, False, True)),
+    ("%1945", (False, False, True)),
+    ("%1945-01", (False, False, True)),
+    ("%1945-01-01", (False, False, True)),
 )
 
 BAD_EXAMPLES = (


### PR DESCRIPTION
This PR corrects two issues with PartialUncertainOrApproximate:

* Dates with an uncertainty and/or approximation (UA) marker to the left of the year were not flagged as uncertain and/or approximate
* Dates without a month (e.g., `~1945`) were stringifying as `~1945-None` instead of the expected `~1945`.